### PR TITLE
update telemtery.rb for for better decode

### DIFF
--- a/lib/logstash/codecs/telemetry.rb
+++ b/lib/logstash/codecs/telemetry.rb
@@ -539,7 +539,11 @@ class LogStash::Codecs::Telemetry< LogStash::Codecs::Base
       sub_tables.each do |sub_table|
         produce_event_from_gpbkv_stream(sub_table,evs_sub,ev[:timest])
       end
-      ev[:content] = evs_sub
+      name = table[:name].to_s
+     if name == ""
+       name = "data_gpbkv"
+     end
+     ev[name] = evs_sub
     end
 
     if evs.class == Hash

--- a/lib/logstash/codecs/telemetry.rb
+++ b/lib/logstash/codecs/telemetry.rb
@@ -540,10 +540,10 @@ class LogStash::Codecs::Telemetry< LogStash::Codecs::Base
         produce_event_from_gpbkv_stream(sub_table,evs_sub,ev[:timest])
       end
       name = table[:name].to_s
-     if name == ""
-       name = "data_gpbkv"
-     end
-     ev[name] = evs_sub
+      if name == ""
+        name = "data_gpbkv"
+      end
+      ev[name] = evs_sub
     end
 
     if evs.class == Hash


### PR DESCRIPTION
This change results into the following changed behavior:
- the data included in the Telemetry field of the telemetry message is now tagged "data_gpbkv" as in the message definition.
- the telemetry tables, which represent the model substructures are now tagged with their identifiers (name) as also provided in the telemetry message itself.
The tag content only remains, if it is a tag name in the message.